### PR TITLE
Update about.yaml

### DIFF
--- a/content/about.yaml
+++ b/content/about.yaml
@@ -8,7 +8,7 @@ content:
     <h3>Mission Statement</h3>
 
     <div class="left max">
-      <p>Founded in 2017, the Creative Commons Community Music Awards aim to be the Grammys of the creative commons world. They seek to distinguish preeminent musical works that incorporate copyleft licenses and veer from the traditional copyright structure. The CCCMAs set the stage for artists that choose to embrace a shared culture, something unique to the current landscape of music award programs.</p>
+      <p>Founded in 2017, the Creative Commons Community Music Awards aim to be the Grammys of the creative commons world. They seek to distinguish preeminent musical works that incorporate Creative Commons licenses and veer from the traditional copyright structure. The CCCMAs set the stage for artists that choose to embrace a shared culture, something unique to the current landscape of music award programs.</p>
 
       <p>The awards are currently juried by <a href="https://ccmusicawards.com/judges.html">a collection of creative commons artists and compatriots</a> involved in said scene. In its primary years, the CCCMAs recognized musicians via genre, but have since expanded to include region-specific talent in effort to highlight free culture across the globe.</p>
 
@@ -188,4 +188,4 @@ content:
     </ul>
     
     <h3>CC Hall of Fame</h3>
-      <p>On the 25th Anniversary of the Creative Commons licenses, the CC CMA organization plans to launch a new endeavor, the CC Hall of Fame. As of writing, this is about 2.5 years away, but it will take a lot of time to do this right! If you would like to be involved with this new project, please email doug@blocsonic.com</p>    
+      <p>On the 30th Anniversary of the Creative Commons licenses, the CC CMA organization plans to launch a new endeavor, the CC Hall of Fame. As of writing, this is about 7 years away, but it will take a lot of time to do this right! If you would like to be involved with this new project, please email doug@blocsonic.com</p>    


### PR DESCRIPTION
Changed the CC Hall of Fame to the 30th anniversary. I don't think there's a reason to take the idea off the site, but I think projectEqualize is a more important project.